### PR TITLE
[Refactor] 플랫폼 별 화면 초기화 로직 모듈화

### DIFF
--- a/ShareCode/ShareCode/MainPage.xaml.cs
+++ b/ShareCode/ShareCode/MainPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using ShareCode.src;
 using ShareCode.src.Platform;
 using System.Collections.ObjectModel;
-using UIKit;
 
 namespace ShareCode;
 
@@ -29,30 +28,11 @@ public partial class MainPage : ContentPage
 
         // Export 버튼은 초기에는 비활성화 상태
         exportButton.IsEnabled = false;
-
-        // Mac Catalyst 전용 창 설정
-#if MACCATALYST
-        ConfigureMacCatalystWindow();
-#else
-        // 다른 플랫폼 (예: Windows)
-        var window = Application.Current!.Windows[0];
-        window.Height = 800; // 원하는 높이로 설정
-        window.Width = 600;  // 원하는 너비로 설정
-        window.MinimumHeight = 800; // 최소 높이 고정
-        window.MinimumWidth = 600;  // 최소 너비 고정
-#endif
+        
+        // 창 크기 조정
+        platformHandler.ConfigureWindow(this);
     }
     
-    private void ConfigureMacCatalystWindow()
-    {
-        if (UIApplication.SharedApplication.ConnectedScenes.FirstOrDefault<object>() is UIWindowScene windowScene)
-        {
-            // 창 크기와 최소/최대 크기 설정
-            windowScene.SizeRestrictions.MinimumSize = new CoreGraphics.CGSize(600, 800); // 최소 크기
-            windowScene.SizeRestrictions.MaximumSize = new CoreGraphics.CGSize(600, 800); // 최대 크기
-        }
-    }
-
     private void OnLanguageChanged(object? sender, CheckedChangedEventArgs e)
     {
         if (sender is RadioButton radioButton && e.Value)

--- a/ShareCode/ShareCode/MainPage.xaml.cs
+++ b/ShareCode/ShareCode/MainPage.xaml.cs
@@ -30,7 +30,7 @@ public partial class MainPage : ContentPage
         exportButton.IsEnabled = false;
         
         // 창 크기 조정
-        platformHandler.ConfigureWindow(this);
+        platformHandler.ConfigureWindow();
     }
     
     private void OnLanguageChanged(object? sender, CheckedChangedEventArgs e)

--- a/ShareCode/ShareCode/src/Platform/MacOSPlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/MacOSPlatformHandler.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using UIKit;
 
 namespace ShareCode.src.Platform
 {
@@ -6,6 +8,19 @@ namespace ShareCode.src.Platform
     {
         public override async Task OnExportButtonClicked(ContentPage page, ObservableCollection<FileItem> fileList)
         {
+        }
+        
+        public override void ConfigureWindow(ContentPage page)
+        {
+            if (UIApplication.SharedApplication.ConnectedScenes.FirstOrDefault<object>() is not UIWindowScene windowScene) return;
+            Debug.Assert(windowScene.SizeRestrictions != null);
+            
+            windowScene.SizeRestrictions.MinimumSize = new CoreGraphics.CGSize(
+                GlobalConstants.WINDOW_MIN_WIDTH, 
+                GlobalConstants.WINDOW_MIN_HEIGHT);
+            windowScene.SizeRestrictions.MaximumSize = new CoreGraphics.CGSize(
+                GlobalConstants.WINDOW_WIDTH, 
+                GlobalConstants.WINDOW_HEIGHT);
         }
     }
 }

--- a/ShareCode/ShareCode/src/Platform/MacOSPlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/MacOSPlatformHandler.cs
@@ -10,7 +10,7 @@ namespace ShareCode.src.Platform
         {
         }
         
-        public override void ConfigureWindow(ContentPage page)
+        public override void ConfigureWindow()
         {
             if (UIApplication.SharedApplication.ConnectedScenes.FirstOrDefault<object>() is not UIWindowScene windowScene) return;
             Debug.Assert(windowScene.SizeRestrictions != null);

--- a/ShareCode/ShareCode/src/Platform/PlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/PlatformHandler.cs
@@ -55,6 +55,6 @@ namespace ShareCode.src.Platform
         }
         
         public abstract Task OnExportButtonClicked(ContentPage page, ObservableCollection<FileItem> fileList);
-        public abstract void ConfigureWindow(ContentPage page);
+        public abstract void ConfigureWindow();
     }
 }

--- a/ShareCode/ShareCode/src/Platform/PlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/PlatformHandler.cs
@@ -55,5 +55,6 @@ namespace ShareCode.src.Platform
         }
         
         public abstract Task OnExportButtonClicked(ContentPage page, ObservableCollection<FileItem> fileList);
+        public abstract void ConfigureWindow(ContentPage page);
     }
 }

--- a/ShareCode/ShareCode/src/Platform/WindowsPlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/WindowsPlatformHandler.cs
@@ -89,7 +89,7 @@ namespace ShareCode.src.Platform
             return $"{new string('-', leftDashCount)}{fileBaseName}{fileExtension}{new string('-', rightDashCount)}";
         }
         
-        public override void ConfigureWindow(ContentPage page)
+        public override void ConfigureWindow()
         {
             var window = Application.Current!.Windows[0];
             window.Height = GlobalConstants.WINDOW_HEIGHT;

--- a/ShareCode/ShareCode/src/Platform/WindowsPlatformHandler.cs
+++ b/ShareCode/ShareCode/src/Platform/WindowsPlatformHandler.cs
@@ -88,5 +88,14 @@ namespace ShareCode.src.Platform
 
             return $"{new string('-', leftDashCount)}{fileBaseName}{fileExtension}{new string('-', rightDashCount)}";
         }
+        
+        public override void ConfigureWindow(ContentPage page)
+        {
+            var window = Application.Current!.Windows[0];
+            window.Height = GlobalConstants.WINDOW_HEIGHT;
+            window.Width = GlobalConstants.WINDOW_WIDTH;
+            window.MinimumHeight = GlobalConstants.WINDOW_MIN_HEIGHT;
+            window.MinimumWidth = GlobalConstants.WINDOW_MIN_WIDTH;
+        }
     }
 }


### PR DESCRIPTION
각 플랫폼 별 화면 초기화 로직이 모듈화 되었습니다
PlatformHandler의 추상메서드를 상속받아 구현합니다

<img width="433" alt="스크린샷 2025-01-08 오후 4 03 19" src="https://github.com/user-attachments/assets/38b95250-54cf-45c9-97e2-9e838c2ff48f" />
